### PR TITLE
feat(calendar): connect to backend and display employee leave requests on calendar

### DIFF
--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -7,6 +7,7 @@ import Button from '../components/Button';
 import { calendarServices } from '../services/calendarServices';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import { useAuthStore } from '../context/authStore'; // Asegurar importación correcta
 
 // Mapeo de colores para los diferentes tipos de ausencia
 const LEAVE_TYPE_COLORS = {
@@ -17,10 +18,13 @@ const LEAVE_TYPE_COLORS = {
 };
 
 const CalendarPage = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false); // Control del modal de solicitud de ausencia
-  const [isVacationModalOpen, setIsVacationModalOpen] = useState(false); // Control del modal de solicitud de vacaciones
-  const [leaveRequestTypes, setLeaveRequestTypes] = useState([]); // Tipos de ausencia disponibles
-  const [events, setEvents] = useState([]); // Eventos del calendario
+  // Obtener el token del store de autenticación
+  const token = useAuthStore((state) => state.token);
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isVacationModalOpen, setIsVacationModalOpen] = useState(false);
+  const [leaveRequestTypes, setLeaveRequestTypes] = useState([]);
+  const [events, setEvents] = useState([]);
   const [formData, setFormData] = useState({
     employee_id: '',
     start_date: '',
@@ -37,43 +41,59 @@ const CalendarPage = () => {
 
   // Función para obtener datos iniciales con useCallback para optimizar rendimiento
   const fetchInitialData = useCallback(async () => {
+    // Verificar que el token exista antes de hacer la solicitud
+    if (!token) {
+      toast.error('No se encontró token de autenticación');
+      return;
+    }
+
     try {
-      // Obtener tipos de solicitudes de ausencia
-      const types = await calendarServices.getLeaveRequestTypes();
-      const filteredTypes = types.filter((type) => type.type !== 'Vacaciones');
-      setLeaveRequestTypes(filteredTypes);
+      const types = await calendarServices.getLeaveRequestTypes(token);
 
-      // Obtener todas las solicitudes de ausencia existentes
-      const requests = await calendarServices.getAllLeaveRequests();
+      const requests = await calendarServices.getAllLeaveRequests(token);
 
-      // Mapear las solicitudes a eventos
-      const calendarEvents = requests.map((request) => {
-        // Verifica que tipo de solicitud y color se asignan correctamente
-        const leaveType =
-          request.type === 'Vacaciones'
-            ? { type: 'Vacaciones', id: 1 }
-            : filteredTypes.find((type) => type.id === request.type_id);
+      const calendarEvents = requests
+        .map((request) => {
+          const startDate = new Date(request.startDate);
+          const endDate = new Date(request.endDate);
 
-        const adjustedEndDate = new Date(request.end_date);
-        adjustedEndDate.setDate(adjustedEndDate.getDate() + 1);
+          if (isNaN(startDate) || isNaN(endDate)) {
+            console.error('Fecha inválida:', request);
+            return null;
+          }
 
-        return {
-          title: leaveType ? leaveType.type : 'Ausencia',
-          start: request.start_date,
-          end: adjustedEndDate.toISOString().split('T')[0],
-          color: LEAVE_TYPE_COLORS[leaveType?.type] || '#6c757d', // Asegúrate de que el color es correcto
-        };
-      });
+          const leaveType = types.find((type) => type.id === request.typeId);
 
+          console.log('Tipo de solicitud encontrado:', leaveType);
+
+          const adjustedEndDate = new Date(endDate);
+          adjustedEndDate.setDate(adjustedEndDate.getDate() + 1);
+
+          return {
+            title: leaveType ? leaveType.type : 'Ausencia',
+            start: startDate.toISOString().split('T')[0],
+            end: adjustedEndDate.toISOString().split('T')[0],
+            color: LEAVE_TYPE_COLORS[leaveType?.type] || '#6c757d',
+          };
+        })
+        .filter((event) => event !== null);
+
+      console.log('Eventos del calendario:', calendarEvents);
       setEvents(calendarEvents);
     } catch (error) {
-      toast.error('Error al cargar datos');
+      console.error('Error al cargar datos:', error);
+      toast.error(
+        'No se pudieron cargar los datos. Por favor, inicie sesión nuevamente.'
+      );
     }
-  }, []);
+  }, [token]);
 
   useEffect(() => {
-    fetchInitialData();
-  }, [fetchInitialData]);
+    // Solo intentar cargar datos si hay un token
+    if (token) {
+      fetchInitialData();
+    }
+  }, [fetchInitialData, token]);
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -104,24 +124,24 @@ const CalendarPage = () => {
         return;
       }
 
-      // Crear la solicitud de ausencia en el backend
-      const newRequest = await calendarServices.createLeaveRequest(formData);
+      // Crear la solicitud de ausencia en el backend pasando el token
+      const newRequest = await calendarServices.createLeaveRequest(
+        formData,
+        token
+      );
 
       // Obtener el tipo de ausencia
       const leaveType = leaveRequestTypes.find(
         (type) => type.id === parseInt(formData.type_id)
       );
 
-      // Asegúrate de que el tipo esté correctamente asignado
       const eventColor = leaveType
         ? LEAVE_TYPE_COLORS[leaveType.type] || '#6c757d'
         : '#6c757d';
 
-      // Ajustar fecha de finalización sumando un día
       const adjustedEndDate = new Date(formData.end_date);
       adjustedEndDate.setDate(adjustedEndDate.getDate() + 1);
 
-      // Crear nuevo evento para el calendario
       const newEvent = {
         title: leaveType ? leaveType.type : 'Ausencia',
         start: formData.start_date,
@@ -129,10 +149,8 @@ const CalendarPage = () => {
         color: eventColor,
       };
 
-      // Actualizar el estado de eventos inmediatamente
       setEvents((prevEvents) => [...prevEvents, newEvent]);
 
-      // Limpiar el formulario y cerrar el modal
       setFormData({
         employee_id: '',
         start_date: '',
@@ -144,6 +162,7 @@ const CalendarPage = () => {
 
       toast.success('Solicitud de ausencia creada exitosamente');
     } catch (error) {
+      console.error('Error al crear solicitud:', error);
       toast.error('Error al crear la solicitud de ausencia');
     }
   };
@@ -160,13 +179,16 @@ const CalendarPage = () => {
         return;
       }
 
-      // Enviar solicitud de vacaciones con los datos correctos
-      const newVacation = await calendarServices.createLeaveRequest({
-        employee_id: vacationData.employee_id,
-        start_date: vacationData.start_date,
-        end_date: vacationData.end_date,
-        details: vacationData.details,
-      });
+      // Enviar solicitud de vacaciones pasando el token
+      const newVacation = await calendarServices.createLeaveRequest(
+        {
+          employee_id: vacationData.employee_id,
+          start_date: vacationData.start_date,
+          end_date: vacationData.end_date,
+          details: vacationData.details,
+        },
+        token
+      );
 
       const adjustedEndDate = new Date(vacationData.end_date);
       adjustedEndDate.setDate(adjustedEndDate.getDate() + 1);
@@ -190,8 +212,8 @@ const CalendarPage = () => {
 
       toast.success('Solicitud de vacaciones creada exitosamente');
     } catch (error) {
+      console.error('Error al crear solicitud de vacaciones:', error);
       toast.error('Error al crear la solicitud de vacaciones');
-      console.error(error);
     }
   };
 

--- a/src/services/calendarServices.js
+++ b/src/services/calendarServices.js
@@ -1,66 +1,81 @@
 import axios from 'axios';
 
-// Base URL for API requests
+// URL base para solicitudes API
 const BASE_URL = 'http://localhost:8000/api';
 
 /**
- * Service layer for handling leave request operations
+ * Crear una instancia de Axios con inyección dinámica de token
+ * @param {string} token - Token de autenticación
+ * @returns {AxiosInstance} Instancia de Axios configurada
  */
+const createAxiosInstance = (token) => {
+  return axios.create({
+    baseURL: BASE_URL,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+};
+
 export const calendarServices = {
   /**
-   * Fetch all leave requests
-   * @returns {Promise} Array of leave requests
+   * Obtener todas las solicitudes de ausencia
+   * @param {string} token - Token de autenticación
+   * @returns {Promise} Lista de solicitudes de ausencia
    */
-  getAllLeaveRequests: async () => {
+  getAllLeaveRequests: async (token) => {
     try {
-      const response = await axios.get(`${BASE_URL}/leave-requests`);
+      const axiosInstance = createAxiosInstance(token);
+      const response = await axiosInstance.get('/leave-requests');
       return response.data;
     } catch (error) {
-      console.error('Error fetching leave requests:', error);
+      console.error('Error al obtener solicitudes de ausencia:', error);
       throw error;
     }
   },
 
   /**
-   * Create a new leave request
-   * @param {Object} leaveRequestData Leave request details
-   * @returns {Promise} Created leave request
+   * Obtener tipos de solicitudes de ausencia
+   * @param {string} token - Token de autenticación
+   * @returns {Promise} Lista de tipos de solicitudes
    */
-  createLeaveRequest: async (leaveRequestData) => {
+  getLeaveRequestTypes: async (token) => {
     try {
-      // Buscar el ID real de tipo "Vacaciones"
-      const typeResponse = await axios.get(`${BASE_URL}/type-requests`);
+      const axiosInstance = createAxiosInstance(token);
+      const response = await axiosInstance.get('/type-requests');
+      return response.data;
+    } catch (error) {
+      console.error('Error al obtener tipos de solicitudes:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Crear una nueva solicitud de ausencia
+   * @param {Object} leaveRequestData - Datos de la solicitud
+   * @param {string} token - Token de autenticación
+   * @returns {Promise} Solicitud creada
+   */
+  createLeaveRequest: async (leaveRequestData, token) => {
+    try {
+      const axiosInstance = createAxiosInstance(token);
+
+      // Obtener ID del tipo de vacaciones
+      const typeResponse = await axiosInstance.get('/type-requests');
       const vacationType = typeResponse.data.find(
         (type) => type.type === 'Vacaciones'
       );
 
       const requestData = {
         ...leaveRequestData,
-        type_id: vacationType ? vacationType.id : null, // Usar el ID numérico de vacaciones
-        status_id: 1, // Default to pending status
+        type_id: vacationType ? vacationType.id : null,
+        status_id: 1, // Estado por defecto "pendiente"
       };
 
-      const response = await axios.post(
-        `${BASE_URL}/leave-requests`,
-        requestData
-      );
+      const response = await axiosInstance.post('/leave-requests', requestData);
       return response.data;
     } catch (error) {
-      console.error('Error creating leave request:', error);
-      throw error;
-    }
-  },
-
-  /**
-   * Fetch leave request types
-   * @returns {Promise} Array of leave request types
-   */
-  getLeaveRequestTypes: async () => {
-    try {
-      const response = await axios.get(`${BASE_URL}/type-requests`);
-      return response.data;
-    } catch (error) {
-      console.error('Error fetching leave request types:', error);
+      console.error('Error al crear solicitud de ausencia:', error);
       throw error;
     }
   },


### PR DESCRIPTION
Connect calendar to backend and display employee leave requests

- Implemented connection to backend to fetch employee leave requests.
- Displayed the leave requests on the calendar with correct event dates and types.
- Added error handling for loading data from the backend.
- Optimized data fetching with token validation.

This PR ensures that employee leave requests are properly displayed in the calendar and synced with the backend.
